### PR TITLE
Add .combine(workflow) / Fix an invalid behavior that ignores the last step

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,3 +12,8 @@ const value = Workflow.create((x: number) => x * 10)
   .run(3);
 
 console.log(value);
+
+const workflow1 = Workflow.create((x: number) => x + 1).then((x) => x * 2).then((x) => x + 1)
+const workflow2 = Workflow.create((x: number) => x * 3).then((x) => `${x}`)
+console.log(workflow1.run(1));
+console.log(workflow1.combine(workflow2).run(1));

--- a/src/monoflow.ts
+++ b/src/monoflow.ts
@@ -26,7 +26,7 @@ export class Workflow<Z, A, B> {
   }
 
   run(value: Z): B {
-    const steps = this._steps;
+    const steps = [...this._steps, this] as Workflow<any, any, any>[];
     let ret: any = value;
     let i = 0;
     while (i < steps.length) {

--- a/src/monoflow.ts
+++ b/src/monoflow.ts
@@ -25,7 +25,7 @@ export class Workflow<Z, A, B> {
     return new Workflow(undefined, fn, [...this._steps, this]);
   }
 
-  combine<T, U>(workflow: Workflow<Z, any, any>): Workflow<Z, T, U> {
+  combine<C>(workflow: Workflow<Z, B, C>): Workflow<Z, B, C> {
     return new Workflow(workflow._ok, workflow._err, [...this._steps, this, ...workflow._steps]);
   }
 

--- a/src/monoflow.ts
+++ b/src/monoflow.ts
@@ -25,6 +25,10 @@ export class Workflow<Z, A, B> {
     return new Workflow(undefined, fn, [...this._steps, this]);
   }
 
+  combine<T>(workflow: Workflow<Z, B, T>): Workflow<Z, A, T> {
+    return new Workflow(workflow._ok, workflow._err, [...this._steps, this, ...workflow._steps]) as any;
+  }
+
   run(value: Z): B {
     const steps = [...this._steps, this] as Workflow<any, any, any>[];
     let ret: any = value;

--- a/src/monoflow.ts
+++ b/src/monoflow.ts
@@ -25,8 +25,8 @@ export class Workflow<Z, A, B> {
     return new Workflow(undefined, fn, [...this._steps, this]);
   }
 
-  combine<T>(workflow: Workflow<Z, B, T>): Workflow<Z, A, T> {
-    return new Workflow(workflow._ok, workflow._err, [...this._steps, this, ...workflow._steps]) as any;
+  combine<T, U>(workflow: Workflow<Z, any, any>): Workflow<Z, T, U> {
+    return new Workflow(workflow._ok, workflow._err, [...this._steps, this, ...workflow._steps]);
   }
 
   run(value: Z): B {


### PR DESCRIPTION
I found the last mapped function doesn't be called.

```ts
const result = Workflow.create((x) => x + 1).then((x) => x * 2).run(1);
// result becomes 2.
```

Also #4 is done.